### PR TITLE
Leverage primary and secondary places texts

### DIFF
--- a/TK.CustomMap/TK.CustomMap.Android/DependencyServices/NativePlacesApi.cs
+++ b/TK.CustomMap/TK.CustomMap.Android/DependencyServices/NativePlacesApi.cs
@@ -59,7 +59,8 @@ namespace TK.CustomMap.Droid
                 result.AddRange(this._buffer.Select(i => 
                     new TKNativeAndroidPlaceResult
                     {
-                        Description = i.Description,
+                        Description = i.GetPrimaryText(null),
+                        Subtitle = i.GetSecondaryText(null),
                         PlaceId = i.PlaceId,
                     }));
             }


### PR DESCRIPTION
The places API provides a primary and secondary text, which matches the "Description" and "Subtitle" fields of TK.Maps' search results. The first is intended as a primary name, the second provide context information. Sample:

Primary: MoMA Design Store
Secondary: West 53rd Street, New York, NY, United States

Rather than squashing everything into a single long string (and even leaving the Subtitle property empty), it makes sense to return those bits separated.
